### PR TITLE
Remove circe-bson reference

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,6 @@ val compilerOptions = Seq(
 
 val circeVersion = "0.11.0"
 val spireVersion = "0.16.0"
-val previousCirceBsonVersion = "0.2.0"
 
 val baseSettings = Seq(
   scalacOptions ++= compilerOptions,


### PR DESCRIPTION
At some point we'll probably want to set up MiMa properly, but there's no rush on that.