### PR TITLE
Use right projection for 2.11

### DIFF
--- a/src/main/scala/io/circe/spire/SpireCodecs.scala
+++ b/src/main/scala/io/circe/spire/SpireCodecs.scala
@@ -34,6 +34,7 @@ trait SpireCodecs {
   implicit val naturalDecoder: Decoder[Natural] = new Decoder[Natural] {
     def apply(c: HCursor): Result[Natural] =
       Decoder[BigInt].apply(c)
+        .right
         .flatMap(big => if (big < BigInt(0)) Left(DecodingFailure("Must be positive", Nil)) else Right(Natural(big)))
   }
 


### PR DESCRIPTION
This will warn once there's a 2.13 build, and at that point I'd probably just pattern match, but we could also use Cats's syntax. For now this seems like the easy solution.