### PR TITLE
Fix key name

### DIFF
--- a/src/main/scala/io/circe/spire/SpireCodecs.scala
+++ b/src/main/scala/io/circe/spire/SpireCodecs.scala
@@ -37,7 +37,7 @@ trait SpireCodecs {
       case Add(a, b) => Json.obj("Add" -> Json.obj("a" -> apply(a), "b" -> apply(b)))
       case Sub(a, b) => Json.obj("Sub" -> Json.obj("a" -> apply(a), "b" -> apply(b)))
       case Mul(a, b) => Json.obj("Mul" -> Json.obj("a" -> apply(a), "b" -> apply(b)))
-      case Div(a, b) => Json.obj("Dib" -> Json.obj("a" -> apply(a), "b" -> apply(b)))
+      case Div(a, b) => Json.obj("Div" -> Json.obj("a" -> apply(a), "b" -> apply(b)))
       case KRoot(a, k) => Json.obj("KRoot" -> Json.obj("a" -> apply(a), "k" -> Json.fromInt(k)))
       case Pow(a, k) => Json.obj("Pow" -> Json.obj("a" -> apply(a), "k" -> Json.fromInt(k)))
     }


### PR DESCRIPTION
`dib` -> `div`.  That's what the [Decoder](https://github.com/circe/circe-spire/blob/a175ac4c6fe29e6cae92651e8fabf7be4b520aef/src/main/scala/io/circe/spire/SpireCodecs.scala#L111) uses :)